### PR TITLE
Removed backplate tab

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -35,9 +35,6 @@
                         <li class="nav-item">
                             <a class="nav-link text-light" asp-area="" asp-controller="Employees" asp-action="AssignNewUserTags">Assign Tag</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-light" asp-area="" asp-controller="Backplates" asp-action="Index">Backplates</a>
-                        </li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
The behavior was not matching the intended behavior and it would add too much complexity to make it work. Users can select a task and then create backplate through the logtime route